### PR TITLE
Update to better support Anthropic

### DIFF
--- a/core/agents/agent_tools.py
+++ b/core/agents/agent_tools.py
@@ -12,6 +12,8 @@ from tenacity import (
 from langchain_core.runnables.base import Runnable
 from langchain_core.runnables.utils import Input
 
+from core.utils.llm_concurrency import llm_concurrency_guard
+
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +231,8 @@ async def ainvoke_with_retry(chain: Runnable, input: Input):
     # inputs = {k: json.dumps(v) for k, v in inputs.items()}  # Uncomment if your inputs need serialization
 
     logger.debug(f"Invoking chain with inputs: {input}")
-    return await chain.ainvoke(input)
+    async with llm_concurrency_guard():
+        return await chain.ainvoke(input)
 
 
 @retry(

--- a/core/agents/chat_model_manager.py
+++ b/core/agents/chat_model_manager.py
@@ -3,18 +3,129 @@ import re
 from langchain.chat_models import init_chat_model
 from langchain_core.rate_limiters import InMemoryRateLimiter
 from langchain_core.language_models.chat_models import BaseChatModel
-from typing import Optional
+from typing import Optional, Dict, Any
 from pydantic import SecretStr
 
 
 logger = logging.getLogger(__name__)
 
-# Initialize rate limiter (Exponential backoff happens in retries)
-rate_limiter = InMemoryRateLimiter(
-    requests_per_second=7,  # OpenAI limit is 500 per minute
-    check_every_n_seconds=0.1,  # Wake up every 100ms to check the limit
-    max_bucket_size=10,  # Maximum burst requests
-)
+# Default rate limiter (used when no provider-specific config is supplied)
+DEFAULT_RATE_LIMIT_PARAMS = {
+    "requests_per_second": 7,  # Aligns with OpenAI's 500 req/min default
+    "check_every_n_seconds": 0.1,
+    "max_bucket_size": 10,
+}
+DEFAULT_RATE_LIMITER = InMemoryRateLimiter(**DEFAULT_RATE_LIMIT_PARAMS)
+# Backwards-compatible alias for existing imports/tests
+rate_limiter = DEFAULT_RATE_LIMITER
+
+_PROVIDER_LIMIT_PARAMS: Dict[str, Dict[str, Any]] = {
+    "anthropic": {
+        "requests_per_second": 50 / 60,  # 50 RPM default across Anthropic plans
+        "check_every_n_seconds": 0.5,
+        "max_bucket_size": 5,
+        "model_caps": {
+            "default": 10000,
+            "claude-3-5-sonnet": 8000,
+            "claude-3-sonnet": 8000,
+            "claude-4.1-sonnet": 8000,
+            "claude-4.1-opus": 8000,
+            "claude-3-5-opus": 8000,
+        },
+    }
+}
+_PROVIDER_RATE_LIMITERS: dict[str, InMemoryRateLimiter] = {}
+
+
+def set_provider_limits(
+    provider: str,
+    *,
+    requests_per_minute: Optional[float] = None,
+    requests_per_second: Optional[float] = None,
+    check_every_n_seconds: Optional[float] = None,
+    max_bucket_size: Optional[int] = None,
+    max_tokens: Optional[int] = None,
+    model_caps: Optional[Dict[str, int]] = None,
+) -> None:
+    """
+    Configure rate limiting and token caps for a given provider.
+
+    Args:
+        provider: Provider name (case-insensitive).
+        requests_per_minute: Optional requests/minute override. Wins over requests_per_second if both provided.
+        requests_per_second: Optional requests/second override.
+        check_every_n_seconds: Frequency that the limiter wakes to replenish tokens.
+        max_bucket_size: Burst capacity for the limiter.
+        max_tokens: Per-request token ceiling to apply when invoking the provider.
+    """
+
+    provider_key = provider.lower()
+    params = _PROVIDER_LIMIT_PARAMS.get(provider_key, {}).copy()
+
+    if requests_per_minute is not None:
+        requests_per_second = requests_per_minute / 60.0
+
+    if requests_per_second is not None:
+        params["requests_per_second"] = max(requests_per_second, 0.01)
+    if check_every_n_seconds is not None:
+        params["check_every_n_seconds"] = max(check_every_n_seconds, 0.01)
+    if max_bucket_size is not None:
+        params["max_bucket_size"] = max(int(max_bucket_size), 1)
+    if model_caps is not None:
+        params["model_caps"] = {k: max(int(v), 1) for k, v in model_caps.items()}
+    if max_tokens is not None:
+        params.setdefault("model_caps", {})
+        params["model_caps"]["default"] = max(int(max_tokens), 1)
+
+    _PROVIDER_LIMIT_PARAMS[provider_key] = params
+    # Discard any cached limiter so it reuses the updated params next time.
+    _PROVIDER_RATE_LIMITERS.pop(provider_key, None)
+
+
+def _get_provider_limits(provider: str) -> Dict[str, Any]:
+    return _PROVIDER_LIMIT_PARAMS.get(provider.lower(), {})
+
+
+def _get_rate_limiter(provider: str) -> InMemoryRateLimiter:
+    provider_key = provider.lower()
+    if provider_key not in _PROVIDER_RATE_LIMITERS:
+        params = _get_provider_limits(provider_key)
+        if params:
+            limiter_kwargs = {
+                "requests_per_second": params.get("requests_per_second")
+                or DEFAULT_RATE_LIMIT_PARAMS["requests_per_second"],
+                "check_every_n_seconds": params.get("check_every_n_seconds")
+                or DEFAULT_RATE_LIMIT_PARAMS["check_every_n_seconds"],
+                "max_bucket_size": int(
+                    params.get("max_bucket_size")
+                    or DEFAULT_RATE_LIMIT_PARAMS["max_bucket_size"]
+                ),
+            }
+            _PROVIDER_RATE_LIMITERS[provider_key] = InMemoryRateLimiter(
+                **limiter_kwargs
+            )
+        else:
+            _PROVIDER_RATE_LIMITERS[provider_key] = DEFAULT_RATE_LIMITER
+    return _PROVIDER_RATE_LIMITERS[provider_key]
+
+
+def _resolve_model_token_cap(limits: Dict[str, Any], model: str) -> Optional[int]:
+    if not limits:
+        return None
+    model_caps = limits.get("model_caps")
+    if isinstance(model_caps, dict):
+        # Exact match
+        if model in model_caps:
+            return int(model_caps[model])
+        # Prefix match for family names
+        for key, value in model_caps.items():
+            if key == "default":
+                continue
+            if model.startswith(key):
+                return int(value)
+        default_cap = model_caps.get("default")
+        return int(default_cap) if default_cap is not None else None
+    return None
 
 
 class ChatModelManager:
@@ -29,7 +140,8 @@ class ChatModelManager:
         temperature: float = 0.0,
         frequency_penalty=0.0,
         presence_penalty=0.0,
-        rate_limiter: Optional[InMemoryRateLimiter] = rate_limiter,
+        rate_limiter: Optional[InMemoryRateLimiter] = None,
+        max_output_tokens: Optional[int] = None,
     ) -> BaseChatModel:
         """
         Get a chat model dynamically based on the provider with rate limiting & retries.
@@ -39,6 +151,7 @@ class ChatModelManager:
             model: The model name to use
             api_key: API key for the provider (if required)
             temperature: Temperature setting for response randomness
+            max_output_tokens: Provider-specific hard limit on generated tokens.
             rate_limiter: Optional rate limiter
             max_retries: Maximum number of retry attempts
 
@@ -46,6 +159,14 @@ class ChatModelManager:
             LangChain-compatible chat model instance with retry functionality
         """
         try:
+            provider_key = provider.lower()
+            limits = _get_provider_limits(provider_key)
+            selected_rate_limiter = (
+                rate_limiter if rate_limiter is not None else _get_rate_limiter(provider_key)
+            )
+            max_token_cap = _resolve_model_token_cap(limits, model)
+            requested_max_tokens = max_output_tokens
+
             init_kwargs = {
                 "model_provider": provider,
                 "model": model,
@@ -53,21 +174,34 @@ class ChatModelManager:
                 "top_p": top_p,
                 "frequency_penalty": frequency_penalty,
                 "presence_penalty": presence_penalty,
-                "rate_limiter": rate_limiter,
+                "rate_limiter": selected_rate_limiter,
             }
-            if provider.lower() == "anthropic":
+            if provider_key == "anthropic":
                 init_kwargs["api_key"] = api_key
 
                 del init_kwargs["frequency_penalty"]
                 del init_kwargs["presence_penalty"]
+                # Anthropic API rejects requests when both temperature and top_p are set.
+                if "top_p" in init_kwargs:
+                    del init_kwargs["top_p"]
+                if requested_max_tokens is not None:
+                    capped_tokens = (
+                        min(requested_max_tokens, max_token_cap)
+                        if max_token_cap is not None
+                        else requested_max_tokens
+                    )
+                    init_kwargs["max_tokens"] = capped_tokens
             elif provider.lower() == "openai":
                 init_kwargs["api_key"] = api_key
 
-                if re.match(r"o\d-", model.lower()):
+                is_reasoning_model = bool(re.match(r"o\d-", model.lower()))
+                if is_reasoning_model:
                     del init_kwargs["top_p"]
                     del init_kwargs["frequency_penalty"]
                     del init_kwargs["presence_penalty"]
                     del init_kwargs["temperature"]
+                elif requested_max_tokens is not None:
+                    init_kwargs["max_tokens"] = requested_max_tokens
 
             elif provider.lower() == "ollama":
                 init_kwargs["base_url"] = base_url

--- a/core/agents/diagram_agent.py
+++ b/core/agents/diagram_agent.py
@@ -47,6 +47,8 @@ class DiagramAgent:
 
         # Pydantic model for LLM results
         class Result(BaseModel):
+            """Tool output capturing the Mermaid diagram produced by the LLM."""
+
             mermaid_diagram: str = Field(
                 ...,
                 description="A Mermaid.js-compatible diagram that visualizes the data flow in the system.",

--- a/core/agents/merge_data_flows_agent.py
+++ b/core/agents/merge_data_flows_agent.py
@@ -86,6 +86,7 @@ class MergeDataFlowAgent:
 
         # Pydantic model for LLM results
         class Result(BaseModel):
+            """Structured response combining merged data flow report and justification."""
 
             data_flow_report: Dict[str, Any] = Field(
                 ...,

--- a/core/agents/mitre_attack_agent.py
+++ b/core/agents/mitre_attack_agent.py
@@ -49,6 +49,8 @@ class AttackGraphStateModel(BaseModel):
 
 
 class Result(BaseModel):
+    """LLM tool schema describing MITRE ATT&CK techniques discovered for a component."""
+
     attacks: List[AgentAttack] = Field(
         default_factory=list,
         description="List of identified attacks based on the MITRE ATT&CK framework.",

--- a/core/agents/repo_data_flow_agent.py
+++ b/core/agents/repo_data_flow_agent.py
@@ -331,6 +331,8 @@ class DataFlowAgent:
 
         # We'll parse the LLM output into these fields
         class CategorizationResult(BaseModel):
+            """Structured categorization results returned by the LLM tool."""
+
             should_review: List[File]
             could_review: List[File]
             should_not_review: List[File]

--- a/core/services/threat_model_config.py
+++ b/core/services/threat_model_config.py
@@ -1,6 +1,6 @@
 from openai import base_url
 from pydantic import Field, SecretStr
-from typing import Literal, ClassVar
+from typing import Literal, ClassVar, Dict
 
 from core.agents.repo_data_flow_agent_config import RepoDataFlowAgentConfig
 
@@ -54,6 +54,38 @@ class ThreatModelConfig(RepoDataFlowAgentConfig):
     generate_data_flow_reports: bool = Field(
         default=True,
         description="Whether to generate data flow reports",
+    )
+
+    anthropic_requests_per_minute: float = Field(
+        default=50.0,
+        description="Anthropic default request limit (requests per minute). Override to match your account quota.",
+    )
+    anthropic_check_every_n_seconds: float = Field(
+        default=0.5,
+        description="Interval for Anthropic rate limiter to replenish its token bucket.",
+    )
+    anthropic_max_bucket_size: int = Field(
+        default=5,
+        description="Burst size for Anthropic rate limiter (maximum queued requests).",
+    )
+    anthropic_per_request_token_cap: int = Field(
+        default=10000,
+        description="Per-request max tokens to request from Anthropic models. Adjust to your account's allowance.",
+    )
+    anthropic_model_token_caps: Dict[str, int] = Field(
+        default_factory=lambda: {
+            "default": 10000,
+            "claude-4.1-sonnet": 8000,
+            "claude-4.1-opus": 8000,
+            "claude-3-5-sonnet": 8000,
+            "claude-3-sonnet": 8000,
+            "claude-3-5-opus": 8000,
+        },
+        description="Per-model token caps for Anthropic models. Keys are prefixes or full model IDs; 'default' applies when no prefix matches.",
+    )
+    anthropic_concurrency_limit: int = Field(
+        default=2,
+        description="Maximum number of concurrent Anthropic LLM requests allowed.",
     )
 
     STRATEGY_PER_REPOSITORY: ClassVar[str] = "per-repository"

--- a/core/services/threat_model_services.py
+++ b/core/services/threat_model_services.py
@@ -139,6 +139,7 @@ async def generate_mitre_attack(
                 provider=config.llm_provider,
                 api_key=config.api_key,
                 model=config.threat_model_agent_llm,
+                max_output_tokens=config.max_output_tokens,
             )
         )
 
@@ -268,11 +269,13 @@ def create_data_flow_agent(
             provider=config.llm_provider,
             api_key=config.api_key,
             model=config.categorization_agent_llm,
+            max_output_tokens=config.max_output_tokens,
         ),
         review_model=ChatModelManager.get_model(
             provider=config.llm_provider,
             api_key=config.api_key,
             model=config.report_agent_llm,
+            max_output_tokens=config.max_output_tokens,
         ),
         directory=directory,
         username=config.username,
@@ -290,6 +293,7 @@ def generate_dataflow_diagram(
             provider=config.llm_provider,
             api_key=config.api_key,
             model=config.report_agent_llm,
+            max_output_tokens=config.max_output_tokens,
         )
     )
 
@@ -337,6 +341,7 @@ async def generate_threats(
                 provider=config.llm_provider,
                 api_key=config.api_key,
                 model=config.threat_model_agent_llm,
+                max_output_tokens=config.max_output_tokens,
             )
         )
 
@@ -386,6 +391,7 @@ async def generate_threat_model_data(
                 provider=config.llm_provider,
                 api_key=config.api_key,
                 model=config.report_agent_llm,
+                max_output_tokens=config.max_output_tokens,
             )
         )
 
@@ -419,6 +425,7 @@ async def merge_data_flows(
                 provider=config.llm_provider,
                 api_key=config.api_key,
                 model=config.report_agent_llm,
+                max_output_tokens=config.max_output_tokens,
             )
         )
 

--- a/core/utils/llm_concurrency.py
+++ b/core/utils/llm_concurrency.py
@@ -1,0 +1,34 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+
+_DEFAULT_LIMIT = 2
+_current_limit = _DEFAULT_LIMIT
+_semaphore = asyncio.Semaphore(_DEFAULT_LIMIT)
+
+
+def set_concurrency_limit(limit: int) -> None:
+    """
+    Set the maximum number of concurrent LLM calls allowed.
+    Resets the underlying semaphore to the new limit.
+    """
+    global _semaphore, _current_limit
+
+    limit = max(1, limit)
+    _current_limit = limit
+    _semaphore = asyncio.Semaphore(limit)
+
+
+def get_concurrency_limit() -> int:
+    """Return the current semaphore capacity."""
+    return _current_limit
+
+
+@asynccontextmanager
+async def llm_concurrency_guard():
+    """Async context manager that enforces the configured concurrency limit."""
+    await _semaphore.acquire()
+    try:
+        yield
+    finally:
+        _semaphore.release()

--- a/tests/core/agents/test_chat_model_manager.py
+++ b/tests/core/agents/test_chat_model_manager.py
@@ -1,6 +1,10 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from core.agents.chat_model_manager import ChatModelManager, rate_limiter
+from core.agents.chat_model_manager import (
+    ChatModelManager,
+    rate_limiter,
+    set_provider_limits,
+)
 from pydantic import SecretStr
 from langchain_core.language_models.chat_models import BaseChatModel
 
@@ -13,24 +17,43 @@ def mock_init_chat_model():
         yield mock
 
 
+@pytest.fixture(autouse=True)
+def reset_provider_limits():
+    """Ensure Anthropic limits are reset for each test run."""
+    set_provider_limits(
+        "anthropic",
+        requests_per_minute=50,
+        check_every_n_seconds=0.5,
+        max_bucket_size=5,
+        max_tokens=10000,
+    )
+    yield
+
+
 @pytest.mark.parametrize(
-    "provider, model, expected_call",
+    "provider, model, extra_kwargs, expected_call",
     [
         (
             "anthropic",
             "test_model",
+            {"max_output_tokens": 2048},
             {
                 "model_provider": "anthropic",
                 "model": "test_model",
                 "temperature": 0.0,
-                "top_p": 1.0,
-                "rate_limiter": rate_limiter,
                 "api_key": SecretStr("test_api_key"),
+                "max_tokens": 2048,
+                "rate_limiter_attrs": {
+                    "requests_per_second": 50 / 60,
+                    "check_every_n_seconds": 0.5,
+                    "max_bucket_size": 5,
+                },
             },
         ),
         (
             "openai",
             "test_model",
+            {"max_output_tokens": 2048},
             {
                 "model_provider": "openai",
                 "model": "test_model",
@@ -38,23 +61,34 @@ def mock_init_chat_model():
                 "top_p": 1.0,
                 "frequency_penalty": 0.0,
                 "presence_penalty": 0.0,
-                "rate_limiter": rate_limiter,
                 "api_key": SecretStr("test_api_key"),
+                "max_tokens": 2048,
+                "rate_limiter_attrs": {
+                    "requests_per_second": rate_limiter.requests_per_second,
+                    "check_every_n_seconds": rate_limiter.check_every_n_seconds,
+                    "max_bucket_size": rate_limiter.max_bucket_size,
+                },
             },
         ),
         (
             "openai",
             "o3-test_model",
+            {"max_output_tokens": 2048},
             {
                 "model_provider": "openai",
                 "model": "o3-test_model",
-                "rate_limiter": rate_limiter,
                 "api_key": SecretStr("test_api_key"),
+                "rate_limiter_attrs": {
+                    "requests_per_second": rate_limiter.requests_per_second,
+                    "check_every_n_seconds": rate_limiter.check_every_n_seconds,
+                    "max_bucket_size": rate_limiter.max_bucket_size,
+                },
             },
         ),
         (
             "ollama",
             "test_model",
+            {},
             {
                 "model_provider": "ollama",
                 "model": "test_model",
@@ -62,20 +96,42 @@ def mock_init_chat_model():
                 "top_p": 1.0,
                 "frequency_penalty": 0.0,
                 "presence_penalty": 0.0,
-                "rate_limiter": rate_limiter,
                 "base_url": "http://localhost:11434",
+                "rate_limiter_attrs": {
+                    "requests_per_second": rate_limiter.requests_per_second,
+                    "check_every_n_seconds": rate_limiter.check_every_n_seconds,
+                    "max_bucket_size": rate_limiter.max_bucket_size,
+                },
             },
         ),
     ],
 )
-def test_get_model(mock_init_chat_model, provider, model, expected_call):
+def test_get_model(mock_init_chat_model, provider, model, extra_kwargs, expected_call):
     """Test model creation with different providers."""
 
     created_model = ChatModelManager.get_model(
-        provider=provider, model=model, api_key=SecretStr("test_api_key")
+        provider=provider,
+        model=model,
+        api_key=SecretStr("test_api_key"),
+        **extra_kwargs,
     )
 
-    mock_init_chat_model.assert_called_once_with(**expected_call)
+    mock_init_chat_model.assert_called_once()
+    _, kwargs = mock_init_chat_model.call_args
+
+    expected_rl_attrs = expected_call.pop("rate_limiter_attrs", None)
+    rate_limiter_arg = kwargs.pop("rate_limiter")
+    if expected_rl_attrs:
+        assert pytest.approx(rate_limiter_arg.requests_per_second) == pytest.approx(
+            expected_rl_attrs["requests_per_second"]
+        )
+        assert pytest.approx(rate_limiter_arg.check_every_n_seconds) == pytest.approx(
+            expected_rl_attrs["check_every_n_seconds"]
+        )
+        assert rate_limiter_arg.max_bucket_size == expected_rl_attrs["max_bucket_size"]
+
+    for key, value in expected_call.items():
+        assert kwargs.get(key) == value
     assert isinstance(created_model, BaseChatModel)
 
 


### PR DESCRIPTION
- Let configs tune Anthropic usage: added per-plan request limits, per-model token caps, and a semaphore-based concurrency guard so Claude calls respect quota no matter the tier.
- Updated the chat model manager to honor those limits, cap tokens by model family, and still support OpenAI/Ollama defaults.
- Wired the new knobs through main.py and ThreatModelConfig, added Anthropic-specific defaults, and refreshed tests to cover the new behavior.